### PR TITLE
Make window object the default parameter instead of forcing it

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const events = require('events')
 const through2 = require('through2')
 const inherits = require('inherits')
+const WebSocket = (typeof window !== 'undefined' && window.WebSocket) ? window.WebSocket : null
 
-function SignalhubWs (app, urls) {
+function SignalhubWs (app, urls, WebSocketClass) {
   this.opened = false
   this.sockets = []
   this.app = app
@@ -25,7 +26,7 @@ function SignalhubWs (app, urls) {
   let countOpen = 0
 
   for (let index = 0; index < urls.length; index++) {
-    const socket = new window.WebSocket(`${urls[index]}/${app}`)
+    const socket = new WebSocketClass(`${urls[index]}/${app}`)
 
     this.sockets.push(socket)
 
@@ -167,6 +168,9 @@ SignalhubWs.prototype._closeChannels = function (cb) {
   }
 }
 
-module.exports = function (app, urls) {
-  return new SignalhubWs(app, urls)
+module.exports = function (app, urls, WebSocketClass = WebSocket) {
+  if (!WebSocketClass) {
+    throw TypeError('No WebSocket class given.')
+  }
+  return new SignalhubWs(app, urls, WebSocketClass)
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "bin.js",
   "scripts": {
-    "test": "standard && tape test.js",
+    "test": "standard && tape tests/**/*.test.js",
     "start": "node bin.js"
   },
   "keywords": [],

--- a/test.js
+++ b/test.js
@@ -1,8 +1,9 @@
+global.window = {}
+window.WebSocket = require('websocket').w3cwebsocket
+
 var server = require('./server')()
 var client = require('./index')
 var tape = require('tape')
-global.window = {}
-window.WebSocket = require('websocket').w3cwebsocket
 
 server.listen(9000, function () {
   tape('subscribe', function (t) {

--- a/tests/browser.test.js
+++ b/tests/browser.test.js
@@ -1,0 +1,14 @@
+global.window = {}
+window.WebSocket = require('websocket').w3cwebsocket
+var test = require('tape')
+
+var macro = require('./util-macro')
+
+var server = require('../server')()
+var browserClient = require('../index')
+
+var PORT = 9000
+
+server.listen(PORT, () => {
+  macro(test, server, browserClient, PORT)
+})

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,15 @@
+var test = require('tape')
+
+var macro = require('./util-macro')
+
+var server = require('../server')()
+var browserClient = require('../index')
+
+var serverClient = (app, urls) =>
+    browserClient(app, urls, require('websocket').w3cwebsocket)
+
+var PORT = 9001
+
+server.listen(PORT, () => {
+  macro(test, server, serverClient, PORT)
+})

--- a/tests/util-macro.js
+++ b/tests/util-macro.js
@@ -1,13 +1,7 @@
-global.window = {}
-window.WebSocket = require('websocket').w3cwebsocket
-
-var server = require('./server')()
-var client = require('./index')
-var tape = require('tape')
-
-server.listen(9000, function () {
-  tape('subscribe', function (t) {
-    var c = client('app', ['localhost:9000'])
+/* Macro test utility */
+module.exports = function (test, server, client, port) {
+  test('subscribe', function (t) {
+    var c = client('app', [`localhost:${port}`])
 
     c.subscribe('hello').on('data', function (message) {
       t.same(message, {hello: 'world'})
@@ -18,11 +12,11 @@ server.listen(9000, function () {
     })
   })
 
-  tape('subscribe two apps', function (t) {
+  test('subscribe two apps', function (t) {
     t.plan(2)
 
     var missing = 2
-    var c1 = client('app1', ['localhost:9000'])
+    var c1 = client('app1', [`localhost:${port}`])
 
     c1.subscribe('hello').on('data', function (message) {
       t.same(message, {hello: 'world'})
@@ -31,7 +25,7 @@ server.listen(9000, function () {
       c1.broadcast('hello', {hello: 'world'})
     })
 
-    var c2 = client('app2', ['localhost:9000'])
+    var c2 = client('app2', [`localhost:${port}`])
 
     c2.subscribe('hello').on('data', function (message) {
       t.same(message, {hello: 'world'})
@@ -50,8 +44,8 @@ server.listen(9000, function () {
     }
   })
 
-  tape('subscribe with trailing /', function (t) {
-    var c = client('app', ['localhost:9000/'])
+  test('subscribe with trailing /', function (t) {
+    var c = client('app', [`localhost:${port}/`])
 
     c.subscribe('hello').on('data', function (message) {
       t.same(message, {hello: 'world'})
@@ -62,8 +56,8 @@ server.listen(9000, function () {
     })
   })
 
-  tape('subscribe to many', function (t) {
-    var c = client('app', ['localhost:9000'])
+  test('subscribe to many', function (t) {
+    var c = client('app', [`localhost:${port}`])
     var msgs = ['stranger', 'friend']
 
     c.subscribe(['hello', 'goodbye']).on('data', function (message) {
@@ -81,8 +75,8 @@ server.listen(9000, function () {
     })
   })
 
-  tape('close multiple', function (t) {
-    var c = client('app', ['localhost:9000'])
+  test('close multiple', function (t) {
+    var c = client('app', [`localhost:${port}`])
 
     c.subscribe(['hello', 'goodbye'])
     c.subscribe(['hi', 'bye'])
@@ -92,8 +86,8 @@ server.listen(9000, function () {
     })
   })
 
-  tape('subscribe to channels with slash in the name', function (t) {
-    var c = client('app', ['localhost:9000'])
+  test('subscribe to channels with slash in the name', function (t) {
+    var c = client('app', [`localhost:${port}`])
 
     c.subscribe('hello/people').on('data', function (message) {
       t.same(message, [1, 2, 3])
@@ -104,10 +98,10 @@ server.listen(9000, function () {
     })
   })
 
-  tape('open emitted with multiple hubs', function (t) {
+  test('open emitted with multiple hubs', function (t) {
     var c = client('app', [
-      'localhost:9000',
-      'localhost:9000'
+      `localhost:${port}`,
+      `localhost:${port}`
     ])
     c.subscribe('hello').on('open', function () {
       t.ok(true, 'got an open event')
@@ -116,8 +110,8 @@ server.listen(9000, function () {
     })
   })
 
-  tape('subscribe to channels with slash in the url', function (t) {
-    var c = client('app', ['localhost:9000/foo'])
+  test('subscribe to channels with slash in the url', function (t) {
+    var c = client('app', [`localhost:${port}/foo`])
 
     c.subscribe('hello/bar').on('data', function (message) {
       t.same(message, [1, 2, 3])
@@ -128,9 +122,9 @@ server.listen(9000, function () {
     })
   })
 
-  tape('end', function (t) {
+  test('end', function (t) {
     server.close()
     t.ok(true)
     t.end()
   })
-})
+}


### PR DESCRIPTION
Related issue: #2 
Refactor window into the argument. This allows consumer of this module to use their own websocket client implementation.