### PR TITLE
Use arrow function for channel `close` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ SignalhubWs.prototype.subscribe = function (channel) {
   // use a stream for channel
   this.channels.set(channel, through2.obj())
 
-  this.channels.get(channel).on('close', function () {
+  this.channels.get(channel).on('close', () => {
     this.channels.remove(channel)
   })
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ SignalhubWs.prototype.subscribe = function (channel) {
   this.channels.set(channel, through2.obj())
 
   this.channels.get(channel).on('close', () => {
-    this.channels.remove(channel)
+    this.channels.delete(channel)
   })
 
   if (this.opened) {


### PR DESCRIPTION
I was having errors throw when I invoked `subscription.destroy()`. It was complaining that `this.channels` was undefined [here](https://github.com/soyuka/signalhubws/blob/master/index.js#L63) because the `this` context was lost.

Changing the callback to be an arrow function should fix that.