### PR TITLE
Make sure close cb is always invoked

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,10 @@ SignalhubWs.prototype.onMessage = function (message) {
 }
 
 SignalhubWs.prototype.close = function (cb) {
-  if (this.closed) return
+  if (this.closed) {
+    if(cb) process.nextTick(cb)
+    return
+  }
 
   this.once('close:socket', () => {
     this._closeChannels(cb)
@@ -142,7 +145,10 @@ SignalhubWs.prototype.close = function (cb) {
 }
 
 SignalhubWs.prototype._closeChannels = function (cb) {
-  if (this.closed) return
+  if (this.closed) {
+    if(cb) process.nextTick(cb)
+    return
+  }
   this.closed = true
 
   if (cb) {

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ SignalhubWs.prototype.onMessage = function (message) {
 
 SignalhubWs.prototype.close = function (cb) {
   if (this.closed) {
-    if(cb) process.nextTick(cb)
+    if (cb) process.nextTick(cb)
     return
   }
 
@@ -146,7 +146,7 @@ SignalhubWs.prototype.close = function (cb) {
 
 SignalhubWs.prototype._closeChannels = function (cb) {
   if (this.closed) {
-    if(cb) process.nextTick(cb)
+    if (cb) process.nextTick(cb)
     return
   }
   this.closed = true


### PR DESCRIPTION
I was having issues in dat-js where sometimes a signalhub would get closed more than once. What happened is the whole process would stall since the cb wasn't getting invoked.

This will now guarantee that any callbacks passed to `close` will always get invoked.